### PR TITLE
Add pytest tests for utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# PythonCode
+
+This repository contains various Jupyter notebooks along with a Python module
+`hexagon_tessellation_games_of_quasi_quanta_topology.py`.
+
+## Running Tests
+
+Tests are located in the `tests/` directory and use `pytest`. Install the
+required dependencies and run:
+
+```bash
+pip install -r requirements.txt  # optional if a requirements file is provided
+pip install numpy networkx pytest  # minimal dependencies
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+networkx
+pytest
+

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,20 @@
+import networkx as nx
+import pytest
+
+from .util_loader import load_functions
+
+safe_divide, logic_vector = load_functions()
+
+
+def test_safe_divide_normal():
+    assert safe_divide(10, 2) == 5
+
+
+def test_safe_divide_near_zero():
+    assert safe_divide(1, 1e-12) == 0
+
+
+def test_logic_vector_returns_value():
+    G = nx.DiGraph()
+    G.add_node("phi_eq_psi", value=0.42)
+    assert logic_vector(G, "phi_eq_psi") == pytest.approx(0.42)

--- a/tests/util_loader.py
+++ b/tests/util_loader.py
@@ -1,0 +1,20 @@
+import ast
+import types
+import pathlib
+
+
+def load_functions():
+    path = pathlib.Path(__file__).resolve().parents[1] / 'hexagon_tessellation_games_of_quasi_quanta_topology.py'
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+    selected = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            selected.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in {'safe_divide', 'logic_vector'}:
+            selected.append(node)
+    module = types.ModuleType('extracted')
+    code = compile(ast.Module(body=selected, type_ignores=[]), filename=str(path), mode='exec')
+    exec(code, module.__dict__)
+    return module.safe_divide, module.logic_vector
+


### PR DESCRIPTION
## Summary
- add `pytest` based tests for `safe_divide` and `logic_vector`
- include a small utility loader to avoid executing notebook code
- document how to run tests with `pytest`
- provide minimal `requirements.txt`

## Testing
- `pip install -q numpy networkx pytest matplotlib sympy ipywidgets`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684693616d148327959025510969ebe3