### PR TITLE
Fix duplicate function names

### DIFF
--- a/hexagon_tessellation_games_of_quasi_quanta_topology.py
+++ b/hexagon_tessellation_games_of_quasi_quanta_topology.py
@@ -205,7 +205,7 @@ hex_centers = [(i, j) for i in np.arange(domain[0], domain[1], hex_size)
 t_slider = widgets.FloatSlider(value=0, min=0, max=50, step=0.1, description="Time", continuous_update=False)
 
 @widgets.interact(t=t_slider)
-def update_visualizations(t):
+def update_visualizations_symbolic(t):
     clear_output(wait=True)
     fig, ax = plt.subplots(figsize=(10, 10))
 
@@ -267,7 +267,7 @@ t_slider = widgets.FloatSlider(value=0, min=0, max=50, step=0.1, description="Ti
 
 # Main update function for the visualization
 @widgets.interact(t=t_slider)
-def update_visualizations(t):
+def update_visualizations_normalized(t):
     clear_output(wait=True)
     fig, ax = plt.subplots(figsize=(10, 10))
 
@@ -332,7 +332,7 @@ t_slider = widgets.FloatSlider(value=0, min=0, max=50, step=0.1, description="Ti
 
 # Visualization function that applies the interpretive quasi-quanta function
 @widgets.interact(t=t_slider)
-def update_visualizations(t):
+def update_visualizations_quasi(t):
     clear_output(wait=True)
     fig, ax = plt.subplots(figsize=(10, 10))
 


### PR DESCRIPTION
## Summary
- rename multiple `update_visualizations` helpers to avoid overwriting each other

## Testing
- `python -m py_compile hexagon_tessellation_games_of_quasi_quanta_topology.py`
- `MPLBACKEND=Agg python hexagon_tessellation_games_of_quasi_quanta_topology.py` *(fails: KeyboardInterrupt during plt.pause)*

------
https://chatgpt.com/codex/tasks/task_e_6846927b89a083278190a9961419a2ba